### PR TITLE
Adjust init methods

### DIFF
--- a/Radio/Radio.h
+++ b/Radio/Radio.h
@@ -79,7 +79,8 @@
 	NSString *connectionUserAgent;
 }
 
-- (id)init:(NSString *)userAgent;
+- (id)init:(NSString *)userAgent __deprecated_msg("Use initWithUserAgent instead");
+- (id)initWithUserAgent:(NSString *)userAgent;
 - (BOOL)connect:(NSString *)url withDelegate:(NSObject<RadioDelegate> *)delegate withGain:(float)gain;
 - (void)updateGain:(float)value;
 - (void)updatePlay:(BOOL)play;

--- a/Radio/Radio.m
+++ b/Radio/Radio.m
@@ -37,16 +37,27 @@
 
 #pragma mark - stream connection
 
-- (id)init:(NSString *)userAgent {
+- (id)init {
     self = [super init];
-	if (self != nil) {
-		playing = YES;
-		stopped = NO;
-		connectionUserAgent = userAgent;
+    if (self != nil) {
+        playing = YES;
+        stopped = NO;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleInterruption:) name:AVAudioSessionInterruptionNotification object:[AVAudioSession sharedInstance]];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRouteChange:) name:AVAudioSessionRouteChangeNotification object:[AVAudioSession sharedInstance]];
-	}
-	return self;
+    }
+    return self;
+}
+
+- (id)initWithUserAgent:(NSString *)userAgent {
+    self = [self init];
+    if (self != nil) {
+        connectionUserAgent = userAgent;
+    }
+    return self;
+}
+
+- (id)init:(NSString *)userAgent {
+    return [self initWithUserAgent:userAgent];
 }
 
 - (BOOL)connect: (NSString *)connectUrl withDelegate:(NSObject <RadioDelegate> *)delegate withGain:(float)gain {
@@ -91,7 +102,7 @@
         NSLog(@"connecting to url %@", u);
     }
 	NSMutableURLRequest *req = [[NSMutableURLRequest alloc] initWithURL:u];
-	[req setCachePolicy:NSURLCacheStorageNotAllowed];
+    [req setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
 	[req setValue:@"1" forHTTPHeaderField:@"icy-metadata"];
 	[req setValue:@"no-cache" forHTTPHeaderField:@"Cache-Control"];
 	[req setValue:connectionUserAgent forHTTPHeaderField:@"User-Agent"];

--- a/iOS Radio/RadioViewController.m
+++ b/iOS Radio/RadioViewController.m
@@ -42,7 +42,7 @@
     self.view.clipsToBounds = YES;
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
-    radio = [[Radio alloc] init:@"my app"];
+    radio = [[Radio alloc] initWithUserAgent:@"my app"];
     [radio connect:STREAM_URL withDelegate:self withGain:(1.0)];
     playing = YES;
     


### PR DESCRIPTION
Adjusted init methods to follow standard naming conventions (and facilitate Swift interoperability), specifically
- Deprecated `-(id)init:(NSString *)userAgent`
- Added `-(id)initWithUserAgent:(NSString *)userAgent`

While I was here, I also fixed the cache policy for the request
